### PR TITLE
Use correct field separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -3,7 +3,7 @@ Match	KEYWORD2
 Target	KEYWORD2
 GetMatch	KEYWORD2
 GetCapture	KEYWORD2
-GetResult KEYWORD2
-MatchCount KEYWORD2
-GlobalMatch KEYWORD2
-GlobalReplace KEYWORD2
+GetResult	KEYWORD2
+MatchCount	KEYWORD2
+GlobalMatch	KEYWORD2
+GlobalReplace	KEYWORD2


### PR DESCRIPTION
The Arduino IDE requires the use of a single true tab separator between the keyword name and identifier. When spaces are used rather than a true tab, the keyword is not highlighted.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords